### PR TITLE
refresh button of online debug page add state change event.

### DIFF
--- a/bistoury-ui/src/main/webapp/js/debug.js
+++ b/bistoury-ui/src/main/webapp/js/debug.js
@@ -871,8 +871,12 @@ $(document).ready(function () {
                 }
             }],
             onRefresh: function () {
+                $("button[name='refresh']").attr('disabled', true);
                 $('#jar-debug-table').bootstrapTable('removeAll');
                 getAllClass();
+                setTimeout(function () {
+                    $("button[name='refresh']").attr('disabled', false);
+                }, 3000);
             }
         });
     }


### PR DESCRIPTION
避免在线debug 刷新按钮快速刷新导致的bistoury.result对象拼接出错，进而出现json解析失败