### PR TITLE
统一替换shell脚本声明为bash， 以增强os兼容性

### DIFF
--- a/bistoury-dist/bin/base.sh
+++ b/bistoury-dist/bin/base.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 TIMESTAMP=$(date +%s)

--- a/bistoury-dist/bin/bistoury-agent-env.sh
+++ b/bistoury-dist/bin/bistoury-agent-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 BISTOURY_STORY_PATH="$BISTOURY_STORE_DIR"

--- a/bistoury-dist/bin/bistoury-agent.sh
+++ b/bistoury-dist/bin/bistoury-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 BISTOURY_BIN="${BASH_SOURCE-$0}"

--- a/bistoury-dist/bin/qjmap.sh
+++ b/bistoury-dist/bin/qjmap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BISTOURY_BIN="${BASH_SOURCE-$0}"
 BISTOURY_BIN="$(dirname "$BISTOURY_BIN")"

--- a/bistoury-dist/bin/qjmxcli.sh
+++ b/bistoury-dist/bin/qjmxcli.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BISTOURY_BIN="${BASH_SOURCE-$0}"
 BISTOURY_BIN="$(dirname "$BISTOURY_BIN")"

--- a/bistoury-dist/bin/qjtop.sh
+++ b/bistoury-dist/bin/qjtop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BISTOURY_BIN="${BASH_SOURCE-$0}"
 BISTOURY_BIN="$(dirname "$BISTOURY_BIN")"

--- a/bistoury-proxy/src/bin/base.sh
+++ b/bistoury-proxy/src/bin/base.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 TIMESTAMP=$(date +%s)

--- a/bistoury-proxy/src/bin/bistoury-proxy-env.sh
+++ b/bistoury-proxy/src/bin/bistoury-proxy-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 JAVA_HOME="/tmp/bistoury/java"

--- a/bistoury-proxy/src/bin/bistoury-proxy.sh
+++ b/bistoury-proxy/src/bin/bistoury-proxy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 BISTOURY_BIN="${BASH_SOURCE-$0}"
 BISTOURY_BIN="$(dirname "$BISTOURY_BIN")"

--- a/bistoury-ui/src/bin/base.sh
+++ b/bistoury-ui/src/bin/base.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 TIMESTAMP=$(date +%s)

--- a/bistoury-ui/src/bin/bistoury-ui-env.sh
+++ b/bistoury-ui/src/bin/bistoury-ui-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 JAVA_HOME="/tmp/bistoury/java"

--- a/bistoury-ui/src/bin/bistoury-ui.sh
+++ b/bistoury-ui/src/bin/bistoury-ui.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 BISTOURY_BIN="${BASH_SOURCE-$0}"
 BISTOURY_BIN="$(dirname "$BISTOURY_BIN")"

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd "${0%/*}"
 cd ..

--- a/script/h2/h2.sh
+++ b/script/h2/h2.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 H2_DIR=`pwd`
 H2_LOG_FILE=$H2_DIR/h2.log

--- a/script/quick_start.sh
+++ b/script/quick_start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BISTOURY_BASE_DIR=`pwd`
 

--- a/script/quick_start_build.sh
+++ b/script/quick_start_build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd "${0%/*}"
 


### PR DESCRIPTION
大部shell脚本实际为bash，当os默认的/bin/sh不是bash时，就会有兼容问题，故统一替换为bash
```
find . -name "*.sh" | xargs sed -i 's@^#!/bin/sh@#!/bin/bash@g'
```