### PR TITLE
UI登录密码改采用更安全的加密策略及可通过-Dbistoury.ui.register_disabled=true来禁用帐号注册功能

### DIFF
--- a/bistoury-ui-service-impl/pom.xml
+++ b/bistoury-ui-service-impl/pom.xml
@@ -36,6 +36,43 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
+        <dependency>
+           <groupId>org.slf4j</groupId>
+           <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+          <version>1.64</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.springframework.security</groupId>
+          <artifactId>spring-security-core</artifactId>
+          <version>4.2.13.RELEASE</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-beans</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-context</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-aop</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-expression</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-core</artifactId>
+            </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>
@@ -50,4 +87,14 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 </project>

--- a/bistoury-ui-service-impl/src/main/java/qunar/tc/bistoury/ui/security/PasswordEncoderMain.java
+++ b/bistoury-ui-service-impl/src/main/java/qunar/tc/bistoury/ui/security/PasswordEncoderMain.java
@@ -1,0 +1,13 @@
+ package qunar.tc.bistoury.ui.security;
+
+import qunar.tc.bistoury.ui.service.impl.UserServiceImpl;
+
+public class PasswordEncoderMain {
+
+    public static void main(String[] args) {
+        String rawPassword = args == null || args.length < 1 ? "admin" : args[0];
+        String encodePwd = UserServiceImpl.encodePwd(rawPassword);
+        System.out.println("rawPassword: " + rawPassword + " encodePwd: " + encodePwd);
+    }
+
+}

--- a/bistoury-ui-service-impl/src/main/java/qunar/tc/bistoury/ui/service/impl/PasswordEncoder4OldAESCryptImpl.java
+++ b/bistoury-ui-service-impl/src/main/java/qunar/tc/bistoury/ui/service/impl/PasswordEncoder4OldAESCryptImpl.java
@@ -1,0 +1,26 @@
+package qunar.tc.bistoury.ui.service.impl;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 此旧为实现，仅为兼容而存在 建议采用默认更安全的加密加密策略，实现需要
+ * 实在需要，请在SPI定义文件META-INF\services\org.springframework.security.crypto.password.PasswordEncoder中配置此实现类
+ * 
+ * @author qxo
+ * @date 2020/01/01
+ */
+public class PasswordEncoder4OldAESCryptImpl implements PasswordEncoder {
+
+    private final AESCryptServiceImpl old = new AESCryptServiceImpl();
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return rawPassword == null ? null : old.encrypt(rawPassword.toString());
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return rawPassword == null ? false : old.encrypt(rawPassword.toString()).equals(encodedPassword);
+    }
+
+}

--- a/bistoury-ui-service-impl/src/main/java/qunar/tc/bistoury/ui/service/impl/UserServiceImpl.java
+++ b/bistoury-ui-service-impl/src/main/java/qunar/tc/bistoury/ui/service/impl/UserServiceImpl.java
@@ -17,22 +17,25 @@
 
 package qunar.tc.bistoury.ui.service.impl;
 
+import java.util.List;
+import java.util.ServiceLoader;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import qunar.tc.bistoury.serverside.configuration.DynamicConfig;
 import qunar.tc.bistoury.serverside.configuration.DynamicConfigLoader;
 import qunar.tc.bistoury.serverside.configuration.local.LocalDynamicConfig;
 import qunar.tc.bistoury.ui.dao.UserDao;
 import qunar.tc.bistoury.ui.model.User;
-import qunar.tc.bistoury.ui.service.AESCryptService;
 import qunar.tc.bistoury.ui.service.UserService;
-
-import javax.annotation.PostConstruct;
-import java.util.List;
 
 /**
  * @author leix.xie
@@ -44,11 +47,18 @@ public class UserServiceImpl implements UserService {
 
     private static final Splitter SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
 
+    private static final PasswordEncoder PASSWORD_ENCODER;
+    static {
+       ServiceLoader<PasswordEncoder> sloader = ServiceLoader.load(PasswordEncoder.class);
+       PASSWORD_ENCODER = sloader.iterator().next();
+    }
+    
+    public static String encodePwd(String rawPassword) {
+        return PASSWORD_ENCODER.encode(rawPassword);
+    }
+    
     @Autowired
     private UserDao userDao;
-
-    @Autowired
-    private AESCryptService aesCryptService;
 
     private List<String> admins;
 
@@ -61,14 +71,22 @@ public class UserServiceImpl implements UserService {
     @Override
     public boolean login(User user) {
         User checkUser = this.userDao.getUserByUserCode(user.getUserCode());
-        if (checkUser == null || !this.aesCryptService.encrypt(user.getPassword()).equals(checkUser.getPassword())) {
+        if (checkUser == null || !PASSWORD_ENCODER.matches(user.getPassword(), checkUser.getPassword())) {
             return false;
         }
         return true;
     }
 
+    /**
+     * 为true表示禁止帐号注册功能
+     */
+    private final boolean disable4register = Boolean.getBoolean("bistoury.ui.register_disabled");
+
     @Override
     public int register(User user) {
+        if (disable4register) {
+            throw new IllegalAccessError("User register is disabled!");
+        }
         Preconditions.checkNotNull(user, "user cannot be null");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(user.getUserCode()), "user code cannot be null or empty");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(user.getPassword()), "password cannot be null or empty");
@@ -76,8 +94,18 @@ public class UserServiceImpl implements UserService {
         if (checkUser != null) {
             return -1;
         }
-        user.setPassword(this.aesCryptService.encrypt(user.getPassword()));
+        user.setPassword(PASSWORD_ENCODER.encode(user.getPassword()));
         return this.userDao.registerUser(user);
+    }
+    
+    public boolean changePwd(String uid, String oldPwd, String newPwd) {
+        User checkUser = this.userDao.getUserByUserCode(uid);
+        if (checkUser == null || !PASSWORD_ENCODER.matches(oldPwd, checkUser.getPassword())) {
+            return false;
+        }
+        
+        int ret = userDao.updatePwd(uid, oldPwd, newPwd);
+        return ret > 0;
     }
 
     @Override

--- a/bistoury-ui-service-impl/src/main/resources/META-INF/services/org.springframework.security.crypto.password.PasswordEncoder
+++ b/bistoury-ui-service-impl/src/main/resources/META-INF/services/org.springframework.security.crypto.password.PasswordEncoder
@@ -1,0 +1,3 @@
+org.springframework.security.crypto.password.Pbkdf2PasswordEncoder
+#org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+#org.springframework.security.crypto.scrypt.SCryptPasswordEncoder

--- a/bistoury-ui-service-impl/src/test/java/qunar/tc/bistoury/ui/security/PasswordEncoderTest.java
+++ b/bistoury-ui-service-impl/src/test/java/qunar/tc/bistoury/ui/security/PasswordEncoderTest.java
@@ -1,0 +1,26 @@
+package qunar.tc.bistoury.ui.security;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
+
+public class PasswordEncoderTest {
+
+    @Test
+    public void test() {
+        PasswordEncoder[] passwordEncoders =  new PasswordEncoder[] {
+            new Pbkdf2PasswordEncoder(),
+            new BCryptPasswordEncoder(),
+            new SCryptPasswordEncoder()
+        };
+        final String rawPassword = "password";
+        for (PasswordEncoder passwordEncoder : passwordEncoders) {
+            final String encoded = passwordEncoder.encode(rawPassword);
+            System.out.println(passwordEncoder.getClass()+" src: "+rawPassword + " => "+encoded);
+            Assert.assertTrue(passwordEncoder.matches(rawPassword, encoded));
+        }
+    }
+}

--- a/bistoury-ui/src/bin/bistoury-ui-env.sh
+++ b/bistoury-ui/src/bin/bistoury-ui-env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-
-JAVA_HOME="/tmp/bistoury/java"
-JAVA_OPTS="-Dbistoury.conf=$BISTOURY_COF_DIR -Dbistoury.cache=$BISTOURY_CACHE_DIR"
+set +o nounset
+test -z "$JAVA_HOME" && JAVA_HOME="/tmp/bistoury/java"
+JAVA_OPTS="$JAVA_OPTS -Dbistoury.conf=$BISTOURY_COF_DIR -Dbistoury.cache=$BISTOURY_CACHE_DIR"

--- a/script/h2/data.sql
+++ b/script/h2/data.sql
@@ -1,4 +1,4 @@
-insert into bistoury_user (user_code, password) values ('admin','q1mHvT20zskSnIHSF27d/A==');
+insert into bistoury_user (user_code, password) values ('admin','${admin_pwd}');
 insert into bistoury_app(code, name, group_code, status, creator) values ('bistoury_demo_app','测试应用','tcdev',1,'admin');
 insert into bistoury_user_app (app_code, user_code) values ('bistoury_demo_app','admin');
 insert into bistoury_server (server_id, ip, port, host, log_dir, room, app_code, auto_jstack_enable, auto_jmap_histo_enable) values ('bade8ba7d59b4ca0b91a044739a670aa','${local_ip}',8080,'${local_host}','${log_dir}','al','bistoury_demo_app',1,0);

--- a/script/h2/h2.sh
+++ b/script/h2/h2.sh
@@ -3,13 +3,11 @@
 H2_DIR=`pwd`
 H2_LOG_FILE=$H2_DIR/h2.log
 H2_PID_FILE=$H2_DIR/h2.pid
-BISTOURY_TMP_DIR="/tmp/bistoury"
+test -z "$BISTOURY_TMP_DIR" && BISTOURY_TMP_DIR="/tmp/bistoury"
 H2_PORT_FILE="$BISTOURY_TMP_DIR/h2port.conf"
 
-H2_DATA_BASE_URL="/tmp/bistoury/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;"
+H2_DATA_BASE_URL="${BISTOURY_TMP_DIR}/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;"
 APP_LOG_DIR="\/tmp"
-
-LOCAL_IP=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -1`
 
 H2_PORT=9092;
 echo "$H2_PORT">$H2_PORT_FILE
@@ -36,7 +34,6 @@ else
 fi
 
 start(){
-
     echo "Init tables"
     $JAVA -cp h2-1.4.199.jar org.h2.tools.RunScript -url "jdbc:h2:file:$H2_DATA_BASE_URL" -script ./schema.sql
 
@@ -44,10 +41,13 @@ start(){
     #替换数据库初始化文件中的sql
     local_host=`hostname`
     APP_LOG_DIR=` echo $APP_LOG_DIR | sed 's#\/#\\\/#g'`
-    sed 's/${local_ip}/'$LOCAL_IP'/g' data.sql | sed 's/${local_host}/'$local_host'/g'|sed 's/${log_dir}/'$APP_LOG_DIR'/g' >newdata.sql
 
+    test -z "$LOCAL_IP" && LOCAL_IP=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -1`
+    test -z "$BISTOURY_ADMIN_PWD" && export BISTOURY_ADMIN_PWD="q1mHvT20zskSnIHSF27d/A=="
+    sed 's@${local_ip}@'$LOCAL_IP'@g' data.sql | sed 's@${admin_pwd}@'$BISTOURY_ADMIN_PWD'@g' | \
+    sed 's/${local_host}/'$local_host'/g'|sed 's@${log_dir}@'$APP_LOG_DIR'@g' >newdata.sql
     $JAVA -cp h2-1.4.199.jar org.h2.tools.RunScript -url "jdbc:h2:file:$H2_DATA_BASE_URL" -script ./newdata.sql
-
+    unset BISTOURY_ADMIN_PWD
     rm -rf newdata.sql
 
     echo "Start h2 database"

--- a/script/quick_start.sh
+++ b/script/quick_start.sh
@@ -19,12 +19,19 @@ BISTOURY_AGENT_APP_LIB_CLASS="";
 BISTOURY_TMP_DIR="/tmp/bistoury"
 BISTOURY_PROXY_CONF_FILE="$BISTOURY_TMP_DIR/proxy.conf"
 
-LOCAL_IP=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -1`
-
 start(){
+
+    test -z "$LOCAL_IP" && LOCAL_IP=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -1`
+    export JAVA_OPTS="$JAVA_OPTS -Dbistoury.ui.register_disabled=true"
+    test -z "$BISTOURY_ADMIN_PWD" && BISTOURY_ADMIN_PWD=admin
+    cd  $BISTOURY_UI_BIN_DIR
+    echo "BISTOURY_ADMIN_PWD=$BISTOURY_ADMIN_PWD"
+    export BISTOURY_ADMIN_PWD=$(java -cp '../lib/*' qunar.tc.bistoury.ui.security.PasswordEncoderMain "$BISTOURY_ADMIN_PWD" | awk '/encodePwd:/{print $4}')
+    #echo "BISTOURY_ADMIN_PWD=$BISTOURY_ADMIN_PWD"
 
     cd $H2_DATABASE_DIR
     ./h2.sh -j $2 -i $LOCAL_IP -l $APP_LOG_DIR start
+    unset BISTOURY_ADMIN_PWD
     sleep 5
 
     cd $BISTOURY_PROXY_BIN_DIR


### PR DESCRIPTION
1. 旧实现密码采用AES加密存储，是可逆的，这是不合适的。现改为SPI方式，默认是采用spring-security推荐的Pbkdf2PasswordEncoder
   修改SPI实现配置见：META-INF/services/org.springframework.security.crypto.password.PasswordEncoder
2. quick start方式默认应该禁用帐号注册功能，以避免无意识地引入的安全风险
   同时为了安全建议quick start脚本启动前指定密码，ie: `-DBISTOURY_ADMIN_PWD=xxx`