### PR TITLE
支持windows下运行

### DIFF
--- a/bistoury-dist/bin/bistoury-agent-env.sh
+++ b/bistoury-dist/bin/bistoury-agent-env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-
+set +o nounset
 BISTOURY_STORY_PATH="$BISTOURY_STORE_DIR"
-BISTOURY_PROXY_HOST="127.0.0.1:9090"
-BISTOURY_APP_LIB_CLASS="org.springframework.web.servlet.DispatcherServlet"
-JAVA_HOME="/tmp/bistoury/java"
+test -z "$BISTOURY_PROXY_HOST" && BISTOURY_PROXY_HOST="127.0.0.1:9090"
+test -z "$BISTOURY_APP_LIB_CLASS" && BISTOURY_APP_LIB_CLASS="org.springframework.web.servlet.DispatcherServlet"
+test -z "$JAVA_HOME" && JAVA_HOME="/tmp/bistoury/java"
 JAVA_OPTS="-Dbistoury.store.path=$BISTOURY_STORY_PATH -Dbistoury.proxy.host=$BISTOURY_PROXY_HOST"

--- a/bistoury-dist/bin/bistoury-agent.sh
+++ b/bistoury-dist/bin/bistoury-agent.sh
@@ -6,9 +6,6 @@ BISTOURY_BIN="$(dirname "$BISTOURY_BIN")"
 BISTOURY_BIN_DIR="$(cd "$BISTOURY_BIN"; pwd)"
 BISTOURY_MAIN="qunar.tc.bistoury.indpendent.agent.Main"
 
-. "$BISTOURY_BIN_DIR/base.sh"
-. "$BISTOURY_BIN_DIR/bistoury-agent-env.sh"
-
 for CMD in "$@";do true; done
 
 APP_PID=""
@@ -28,6 +25,9 @@ while getopts p:i:j:c:h opt;do
            exit 0
     esac
 done
+
+. "$BISTOURY_BIN_DIR/base.sh"
+. "$BISTOURY_BIN_DIR/bistoury-agent-env.sh"
 
 if [[ "$JAVA_HOME" != "" ]];then
     JAVA="$JAVA_HOME/bin/java"

--- a/bistoury-serverside-common/src/main/java/qunar/tc/bistoury/serverside/database/H2DataBeseUtil.java
+++ b/bistoury-serverside-common/src/main/java/qunar/tc/bistoury/serverside/database/H2DataBeseUtil.java
@@ -30,16 +30,21 @@ import java.io.IOException;
  * @describe
  */
 public class H2DataBeseUtil {
-    private static final String portPath = "/tmp/bistoury/h2port.conf";
+    private static final String BISTOURY_TMP_DIR;
+    static {
+        String tmp = System.getenv("BISTOURY_TMP_DIR");
+        BISTOURY_TMP_DIR = tmp == null || tmp.length() < 1 ? "/tmp/bistoury" : tmp;
+    }
+    private static final String portPath = BISTOURY_TMP_DIR + "/h2port.conf";
 
     public String getUrl() {
         try {
             String port = getPort();
-            return "jdbc:h2:tcp://localhost:" + port + "//tmp/bistoury/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;";
+            return "jdbc:h2:tcp://localhost:" + port + "/" + BISTOURY_TMP_DIR + "/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;";
         } catch (Exception e) {
             System.err.println("获取h2端口失败，使用默认端口：9092\n" + e);
         }
-        return "jdbc:h2:tcp://localhost//tmp/bistoury/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;";
+        return "jdbc:h2:tcp://localhost/" + BISTOURY_TMP_DIR + "/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;";
     }
 
     public static String getPort() throws IOException {

--- a/bistoury-ui/src/bin/bistoury-ui-env.sh
+++ b/bistoury-ui/src/bin/bistoury-ui-env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-
-JAVA_HOME="/tmp/bistoury/java"
+set +o nounset
+test -z "$JAVA_HOME" && JAVA_HOME="/tmp/bistoury/java"
 JAVA_OPTS="-Dbistoury.conf=$BISTOURY_COF_DIR -Dbistoury.cache=$BISTOURY_CACHE_DIR"

--- a/script/h2/h2.sh
+++ b/script/h2/h2.sh
@@ -3,13 +3,11 @@
 H2_DIR=`pwd`
 H2_LOG_FILE=$H2_DIR/h2.log
 H2_PID_FILE=$H2_DIR/h2.pid
-BISTOURY_TMP_DIR="/tmp/bistoury"
+test -z "$BISTOURY_TMP_DIR" && BISTOURY_TMP_DIR="/tmp/bistoury"
 H2_PORT_FILE="$BISTOURY_TMP_DIR/h2port.conf"
 
-H2_DATA_BASE_URL="/tmp/bistoury/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;"
+H2_DATA_BASE_URL="${BISTOURY_TMP_DIR}/h2/bistoury;MODE=MYSQL;TRACE_LEVEL_SYSTEM_OUT=2;AUTO_SERVER=TRUE;"
 APP_LOG_DIR="\/tmp"
-
-LOCAL_IP=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -1`
 
 H2_PORT=9092;
 echo "$H2_PORT">$H2_PORT_FILE
@@ -29,6 +27,8 @@ while getopts i:j:l:h opt;do
     esac
 done
 
+test -z "$LOCAL_IP" && LOCAL_IP=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"|tail -1`
+
 if [[ "$JAVA_HOME" != "" ]];then
     JAVA="$JAVA_HOME/bin/java"
 else
@@ -44,7 +44,7 @@ start(){
     #替换数据库初始化文件中的sql
     local_host=`hostname`
     APP_LOG_DIR=` echo $APP_LOG_DIR | sed 's#\/#\\\/#g'`
-    sed 's/${local_ip}/'$LOCAL_IP'/g' data.sql | sed 's/${local_host}/'$local_host'/g'|sed 's/${log_dir}/'$APP_LOG_DIR'/g' >newdata.sql
+    sed 's@${local_ip}@'$LOCAL_IP'@g' data.sql | sed 's/${local_host}/'$local_host'/g'|sed 's@${log_dir}@'$APP_LOG_DIR'@g' >newdata.sql
 
     $JAVA -cp h2-1.4.199.jar org.h2.tools.RunScript -url "jdbc:h2:file:$H2_DATA_BASE_URL" -script ./newdata.sql
 


### PR DESCRIPTION
要求在windows系统上有linux子系统: 可以通过安装git+环境变量来添加linux子系统
ie:
1. 下载git: https://git-scm.com/download/win
2. 增加环境变理GIT_HOME=...
3. 然后PATH环境变量中添加如下值即可
%GIT_HOME%\bin;%GIT_HOME%\usr\bin;%GIT_HOME%\cmd;%GIT_HOME%\mingw64\bin

cmd后sh进入linux子系统, 在启用bistoury之前要求设置环境变量如
```
export JAVA_HOME=/D/JDK/jdk1.8.0X64
export LOCAL_IP=127.0.0.1
export BISTOURY_TMP_DIR=J:/tmp/bistoury
export BISTOURY_STORE_DIR=/J/tmp/bistoury
```
这些变量值请视情况修改

启用bistoury命令如下,注意修改$PID为要监牢java应用对应的PID, $APP_CLASS修改为应用中一个类全名,用来定位classpath
```
./quick_start.sh -p  $PID -c "$APP_CLASS"  start
```